### PR TITLE
Opsera Hummingbird AI: Converted Bamboo plan TEST1-TEST1 to GHA

### DIFF
--- a/.github/workflows/TEST1-TEST1.yml
+++ b/.github/workflows/TEST1-TEST1.yml
@@ -1,0 +1,20 @@
+name: Test1
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  Default_Job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+# No triggers equivalent to Bamboo's manual branch creation and deletion
+# No direct equivalent for Bamboo's JIRA linking feature
+# No direct equivalent for Bamboo's concurrent-build-plugin
+
+# Permissions cannot be directly translated to GitHub Actions YAML
+# Consider managing workflow access through GitHub repository settings


### PR DESCRIPTION


pipeline migrated from Bamboo plan [TEST1-TEST1](https://bamboo.shared-private.opsera.io/browse/TEST1-TEST1) to GitHub Actions using Opsera Hummingbird AI
---

### Action Items:
- [ ] Add a repository token as a GitHub Secret if needed for additional repository access.
- [ ] Review and integrate branch management manually, as GitHub Actions does not support the exact Bamboo branch creation/deletion triggers.
- [ ] If JIRA integration is critical, consider using a third-party GitHub Action or manual integration steps.
- [ ] Ensure concurrent build management aligns with organization policies, as this feature is not natively supported in GitHub Actions.
- [ ] Review user and plan permissions within GitHub, as they are not directly translatable from Bamboo.
